### PR TITLE
Potential fix for code scanning alert no. 31: Commented-out code

### DIFF
--- a/analyse/views.py
+++ b/analyse/views.py
@@ -516,29 +516,29 @@ def correlation_and_regression_visualization(request, file_id):
 #                     plot_base64 = base64.b64encode(buffer.getvalue()).decode()
 #                     buffer.close()
 
-#                     reg_plots.append(
-#                         (f"Corrélation entre {col1} et {col2}", plot_base64)
-#                     )
-#         logger.info("Graphiques de régression générés avec succès.")
 
-#         # Rendre le contexte
-#         context = {
-#             "correlation_matrix": correlation_matrix.to_html(classes="table table-striped"),
-#             "heatmap_base64": heatmap_base64,
-#             "reg_plots": reg_plots,
-#             "file_id": file_id,
-#         }
 
-#         return render(
-#             request,
-#             "analysis/correlation_analysis.html",
-#             context,
-#         )
-#     except Exception as e:
-#         # Journaliser les erreurs pour le diagnostic
-#         logger.error(f"Erreur dans correlation_analysis : {str(e)}", exc_info=True)
-#         messages.error(request, "Une erreur est survenue lors de l'analyse.")
-#         return redirect("analyse:upload")
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 # Visualization avec option
 @login_required
 def visualization_options(request, file_id):


### PR DESCRIPTION
Potential fix for [https://github.com/thejokers69/analyseur_donnees/security/code-scanning/31](https://github.com/thejokers69/analyseur_donnees/security/code-scanning/31)

To fix the problem, we should remove the commented-out code. This will make the code cleaner and easier to read. If the commented-out code is needed for future reference, it should be documented elsewhere, such as in version control history or a separate documentation file.

- Remove the commented-out code from lines 519 to 541 in the file `analyse/views.py`.
- Ensure that the remaining code is still functional and that no necessary logic is lost.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
